### PR TITLE
fix: Resource not accessible by integration

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
       - name: Upload assets
         uses: actions/upload-artifact@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -99,6 +99,7 @@ brews:
     repository:
       owner: toolsascode
       name: homebrew-tap
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     commit_author:
       name: carlosrfjunior
       email: carlosrfjunior@gmail.com


### PR DESCRIPTION
- **fix: no linux/macos archives found matching**
- **fix: homebrew tap formula: could not update**
**Reference:** https://goreleaser.com/errors/resource-not-accessible-by-integration/

<img width="1262" alt="image" src="https://github.com/user-attachments/assets/2a5a0514-2c24-4097-9ded-a21a27ab2f80">
